### PR TITLE
Fix empty first or last name in "creator" list

### DIFF
--- a/scripts/push_to_staging_zotero.py
+++ b/scripts/push_to_staging_zotero.py
@@ -199,11 +199,21 @@ def create_item(work, collection_key):
         for a in work["authors_structured"]:
             first = a.get("first")
             last = a.get("last")
-            if first or last:
+            if first and last:
                 creators.append({
                     "creatorType": "author",
                     "firstName": first,
                     "lastName": last
+                })
+            elif first:
+                creators.append({
+                    "creatorType": "author",
+                    "name": first,
+                })
+            elif last:
+                creators.append({
+                    "creatorType": "author",
+                    "name": last,
                 })
     else:
         for author in author_list:
@@ -231,11 +241,21 @@ def create_item(work, collection_key):
                 first = author.get("first") or author.get("firstName")
                 last = author.get("last") or author.get("lastName")
 
-                if first or last:
+                if first and last:
                     creators.append({
                         "creatorType": "author",
                         "firstName": first,
                         "lastName": last
+                    })
+                elif first:
+                    creators.append({
+                        "creatorType": "author",
+                        "name": first,
+                    })
+                elif last:
+                    creators.append({
+                        "creatorType": "author",
+                        "name": last,
                     })
                 elif author.get("display_name"):
                     creators.append({


### PR DESCRIPTION
When a creator (e.g. authors) have a either (but not or) a missing first or last name, it fails to be added to the list of creators. This fix fills in the field "name" instead of "first" and "last" names sepparately, attempting to avoid the exception.